### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# STM32CubeL0 CMSIS Device MCU Component
+# STM32CubeF0 CMSIS Device MCU Component
 
 ![latest tag](https://img.shields.io/github/v/tag/STMicroelectronics/cmsis_device_f0.svg?color=brightgreen)
 


### PR DESCRIPTION
There is `STM32CubeL0 CMSIS Device MCU Component` in title, but this is a F0 repository. This patch fixes the typo.