### PR TITLE
Add support for HSI48 in SystemCoreClockUpdate

### DIFF
--- a/Source/Templates/system_stm32f0xx.c
+++ b/Source/Templates/system_stm32f0xx.c
@@ -224,9 +224,11 @@ void SystemCoreClockUpdate (void)
           STM32F091xC || STM32F098xx || STM32F030xC */
 	  }
       break;
+#if defined(STM32F042x6) || defined(STM32F048xx) || defined(STM32F071xB) || defined(STM32F072xB) || defined(STM32F078xx) || defined(STM32F091xC) || defined(STM32F098xx)
     case RCC_CFGR_SWS_HSI48: /* HSI48 used as system clock */
       SystemCoreClock = HSI48_VALUE;
       break;
+#endif /* STM32F042x6 || STM32F048xx || STM32F071xB || STM32F072xB || STM32F078xx || STM32F091xC || STM32F098xx */
     default: /* HSI used as system clock */
       SystemCoreClock = HSI_VALUE;
       break;

--- a/Source/Templates/system_stm32f0xx.c
+++ b/Source/Templates/system_stm32f0xx.c
@@ -224,6 +224,9 @@ void SystemCoreClockUpdate (void)
           STM32F091xC || STM32F098xx || STM32F030xC */
 	  }
       break;
+    case RCC_CFGR_SWS_HSI48: /* HSI48 used as system clock */
+      SystemCoreClock = HSI48_VALUE;
+      break;
     default: /* HSI used as system clock */
       SystemCoreClock = HSI_VALUE;
       break;


### PR DESCRIPTION
Hi there,

It's me again, please read #2 #1 for background.

I have tried latest version of this repo, and found out that only comments about HSI48 is updated to SystemCoreClockUpdate, but SystemCoreClockUpdate still *DID NOT* handle the case of switching clock source to HSI48, which I believe should fix by add an `case RCC_CFGR_SWS_HSI48 ` clause to the `switch` block. 

I'm asking you to review that again, please.

### copilot summary

This pull request includes an update to the `SystemCoreClockUpdate` function in the `system_stm32f0xx.c` file. The change involves adding support for the HSI48 clock source.

Clock source support:

* [`Source/Templates/system_stm32f0xx.c`](diffhunk://#diff-dc2dd3acdfd0cc07fd48554b6c9e80ef61e2668dbccb5993b0f7c0a2addc3647R227-R229): Added a case for `RCC_CFGR_SWS_HSI48` to set `SystemCoreClock` to `HSI48_VALUE` when HSI48 is used as the system clock.